### PR TITLE
Add string.pack, string.packsize, string.unpack from Lua 5.3

### DIFF
--- a/src/main/java/org/squiddev/cobalt/lib/StringLib.java
+++ b/src/main/java/org/squiddev/cobalt/lib/StringLib.java
@@ -34,6 +34,7 @@ import org.squiddev.cobalt.lib.jse.JsePlatform;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteOrder;
 
 import static org.squiddev.cobalt.Constants.*;
 import static org.squiddev.cobalt.ValueFactory.*;
@@ -54,10 +55,10 @@ public class StringLib implements LuaLibrary {
 	public LuaValue add(LuaState state, LuaTable env) {
 		LuaTable t = new LuaTable();
 		LibFunction.bind(t, StringLib1::new, new String[]{
-			"len", "lower", "reverse", "upper",});
+			"len", "lower", "reverse", "upper", "packsize"});
 		LibFunction.bind(t, StringLibV::new, new String[]{
 			"dump", "byte", "char", "find", "format",
-			"gmatch", "match", "rep", "sub"});
+			"gmatch", "match", "rep", "sub", "pack", "unpack"});
 		LibFunction.bind(t, StringLibR::new, new String[]{"gsub"});
 
 		t.rawset("gfind", t.rawget("gmatch"));
@@ -109,6 +110,9 @@ public class StringLib implements LuaLibrary {
 					}
 					return valueOf(value);
 				}
+				case 4: { // packsize
+					return LuaInteger.valueOf(StringLib.packsize(arg.checkLuaString()));
+				}
 			}
 			return NIL;
 		}
@@ -136,6 +140,10 @@ public class StringLib implements LuaLibrary {
 					return StringLib.rep(args);
 				case 8:
 					return StringLib.sub(args);
+				case 9:
+					return StringLib.pack(args);
+				case 10:
+					return StringLib.unpack(args);
 			}
 			return NONE;
 		}
@@ -603,6 +611,392 @@ public class StringLib implements LuaLibrary {
 		return str_find_aux(state, args, false);
 	}
 
+	private static int packint(long num, int size, byte[] output, int offset, int alignment, ByteOrder endianness, boolean signed) {
+		int total_size = 0;
+		if (offset % Math.min(size, alignment) != 0 && alignment > 1) {
+			for (int i = 0; offset % Math.min(size, alignment) != 0 && i < alignment; i++) {
+				output[offset++] = 0;
+				total_size++;
+			}
+		}
+		if (endianness == ByteOrder.BIG_ENDIAN) {
+			int added_padding = 0;
+			if (size > 8) for (int i = 0; i < size - 8; i++) {
+				output[offset + i] = signed && (num & (1 << (size * 8 - 1))) != 0 ? (byte)0xFF : 0;
+				added_padding++;
+				total_size++;
+			}
+			for (int i = added_padding; i < size; i++) {
+				output[offset + i] = (byte) ((num >> ((size - i - 1) * 8)) & 0xFF);
+				total_size++;
+			}
+		} else {
+			for (int i = 0; i < Math.min(size, 8); i++) {
+				output[offset + i] = (byte) ((num >> (i * 8)) & 0xFF);
+				total_size++;
+			}
+			for (int i = 8; i < size; i++) {
+				output[offset + i] = signed && (num & (1 << (size * 8 - 1))) != 0 ? (byte)0xFF : 0;
+				total_size++;
+			}
+		}
+		return total_size;
+	}
+
+	private static int packoptsize(byte opt, int alignment) {
+		int retval = 0;
+		switch (opt) {
+			case 'b':
+			case 'B':
+			case 'x':
+				retval = 1;
+				break;
+			case 'h':
+			case 'H':
+				retval = 2;
+				break;
+			case 'f':
+			case 'j': // lua_Integer is 32-bit because of bit32 support
+			case 'J':
+				retval = 4;
+				break;
+			case 'l':
+			case 'L':
+			case 'T':
+			case 'd':
+			case 'n':
+				retval = 8;
+				break;
+		}
+		if (alignment > 1 && retval % alignment != 0) retval += (alignment - (retval % alignment));
+		return retval;
+	}
+
+	/**
+	 * string.pack (fmt, v1, v2, ...)
+	 *
+	 * Returns a binary string containing the values v1, v2, etc.
+	 * serialized in binary form (packed) according to the format string fmt.
+	 */
+	static Varargs pack(Varargs args) throws LuaError {
+		LuaString fmt = args.arg(1).checkLuaString();
+		ByteOrder endianness = ByteOrder.nativeOrder();
+		int alignment = 1;
+		int currentSize = 64, pos = 0;
+		int argnum = 2;
+		byte[] output = new byte[currentSize];
+		for (int i = 0; i < fmt.length; i++) {
+			switch (fmt.bytes[i]) {
+				case '<': {
+					endianness = ByteOrder.LITTLE_ENDIAN;
+					break;
+				}
+				case '>': {
+					endianness = ByteOrder.BIG_ENDIAN;
+					break;
+				}
+				case '=': {
+					endianness = ByteOrder.nativeOrder();
+					break;
+				}
+				case '!': {
+					int size = -1;
+					while (i + 1 < fmt.length && fmt.bytes[i + 1] >= '0' && fmt.bytes[i + 1] <= '9') {
+						if (size >= Integer.MAX_VALUE / 10) throw new LuaError("bad argument #1 to 'pack' (invalid format)");
+						size = (Math.max(size, 0) * 10) + (fmt.bytes[++i] - '0');
+					}
+					if (size > 16 || size == 0)
+						throw new LuaError(String.format("integral size (%d) out of limits [1,16]", size));
+					else if (size == -1) { // This is a bit hacky; it will probably need to be rewritten
+						String arch = System.getProperty("os.arch");
+						if (arch.equals("x86_64") || arch.equals("amd64") || arch.equals("x64"))
+							alignment = 8; // assume 8 bytes on 64-bit architectures
+						else alignment = 4; // assume 4 bytes on 32-bit architectures
+					} else alignment = size;
+					break;
+				}
+				case 'b':
+				case 'B':
+				case 'h':
+				case 'H':
+				case 'l':
+				case 'L':
+				case 'j':
+				case 'J':
+				case 'T': {
+					long num = args.arg(argnum++).checkLong();
+					if (num >= Math.pow(2, (packoptsize(fmt.bytes[i], 0) * 8 - (Character.isLowerCase(fmt.bytes[i]) ? 1 : 0))) ||
+						num < (Character.isLowerCase(fmt.bytes[i]) ? -Math.pow(2, (packoptsize(fmt.bytes[i], 0) * 8 - 1)) : 0))
+						throw new LuaError(String.format("bad argument #%d to 'pack' (integer overflow)", argnum - 1));
+					if (pos + packoptsize(fmt.bytes[i], alignment) >= currentSize) {
+						byte[] newoutput = new byte[currentSize + 64];
+						System.arraycopy(output, 0, newoutput, 0, currentSize);
+						output = newoutput;
+						currentSize += 64;
+					}
+					pos += packint(num, packoptsize(fmt.bytes[i], 0), output, pos, alignment, endianness, false);
+					break;
+				}
+				case 'i':
+				case 'I': {
+					boolean signed = fmt.bytes[i] == 'i';
+					int size = -1;
+					while (i + 1 < fmt.length && fmt.bytes[i + 1] >= '0' && fmt.bytes[i + 1] <= '9') {
+						if (size >= Integer.MAX_VALUE / 10) throw new LuaError("bad argument #1 to 'pack' (invalid format)");
+						size = (Math.max(size, 0) * 10) + (fmt.bytes[++i] - '0');
+					}
+					if (size > 16 || size == 0)
+						throw new LuaError(String.format("integral size (%d) out of limits [1,16]", size));
+					else if (alignment > 1 && (size != 1 && size != 2 && size != 4 && size != 8 && size != 16))
+						throw new LuaError("bad argument #1 to 'pack' (format asks for alignment not power of 2)");
+					else if (size == -1) size = 4;
+					long num = args.arg(argnum++).checkLong();
+					if (num >= Math.pow(2, size * 8 - (signed ? 1 : 0)) ||
+						num < (signed ? -Math.pow(2, (size * 8 - 1)) : 0))
+						throw new LuaError(String.format("bad argument #%d to 'pack' (integer overflow)", argnum - 1));
+					if (pos + (size % alignment != 0 ? size + (alignment - (size % alignment)) : size) >= currentSize) {
+						byte[] newoutput = new byte[currentSize + 64];
+						System.arraycopy(output, 0, newoutput, 0, currentSize);
+						output = newoutput;
+						currentSize += 64;
+					}
+					pos += packint(num, size, output, pos, alignment, endianness, signed);
+					break;
+				}
+				case 'f': {
+					float f = (float)args.arg(argnum++).checkDouble();
+					if (pos + 4 >= currentSize) {
+						byte[] newoutput = new byte[currentSize + 64];
+						System.arraycopy(output, 0, newoutput, 0, currentSize);
+						output = newoutput;
+						currentSize += 64;
+					}
+					int l = Float.floatToRawIntBits(f);
+					if (pos % Math.min(4, alignment) != 0 && alignment > 1) for (int j = 0; pos % Math.min(4, alignment) != 0 && j < alignment; j++) output[pos++] = 0;
+					for (int j = 0; j < 4; j++) output[pos + (endianness == ByteOrder.BIG_ENDIAN ? 3 - j : j)] = (byte)((l >> (j * 8)) & 0xFF);
+					pos += 4;
+					break;
+				}
+				case 'd':
+				case 'n': {
+					double f = args.arg(argnum++).checkDouble();
+					if (pos + 8 >= currentSize) {
+						byte[] newoutput = new byte[currentSize + 64];
+						System.arraycopy(output, 0, newoutput, 0, currentSize);
+						output = newoutput;
+						currentSize += 64;
+					}
+					long l = Double.doubleToRawLongBits(f);
+					if (pos % Math.min(8, alignment) != 0 && alignment > 1) for (int j = 0; pos % Math.min(8, alignment) != 0 && j < alignment; j++) output[pos++] = 0;
+					for (int j = 0; j < 8; j++) output[pos + (endianness == ByteOrder.BIG_ENDIAN ? 7 - j : j)] = (byte)((l >> (j * 8)) & 0xFF);
+					pos += 8;
+					break;
+				}
+				case 'c': {
+					int size = 0;
+					if (i + 1 == fmt.length || fmt.bytes[i + 1] < '0' || fmt.bytes[i + 1] > '9')
+						throw new LuaError("missing size for format option 'c'");
+					while (i + 1 < fmt.length && fmt.bytes[i + 1] >= '0' && fmt.bytes[i + 1] <= '9') {
+						if (size >= Integer.MAX_VALUE / 10) throw new LuaError("bad argument #1 to 'pack' (invalid format)");
+						size = (size * 10) + (fmt.bytes[++i] - '0');
+					}
+					if (pos + size < pos || pos + size > Integer.MAX_VALUE) throw new LuaError("bad argument #1 to 'pack' (format result too large)");
+					LuaString str = args.arg(argnum++).checkLuaString();
+					if (str.length > size) throw new LuaError(String.format("bad argument #%d to 'pack' (string longer than given size)", argnum - 1));
+					if (size > 0) {
+						if (pos + size >= currentSize) {
+							int bytestoadd = size % 64 == 0 ? size : size + (64 - (size % 64));
+							byte[] newoutput = new byte[currentSize + bytestoadd];
+							System.arraycopy(output, 0, newoutput, 0, currentSize);
+							output = newoutput;
+							currentSize += bytestoadd;
+						}
+						System.arraycopy(str.bytes, 0, output, pos, Math.min(str.length, size));
+						for (int j = str.length; j < size; j++) output[pos + j] = 0;
+						pos += size;
+					}
+					break;
+				}
+				case 'z': {
+					LuaString str = args.arg(argnum++).checkLuaString();
+					for (byte b : str.bytes) if (b == 0) throw new LuaError(String.format("bad argument #%d to 'pack' (string contains zeros)", argnum - 1));
+					if (pos + str.length + 1 >= currentSize) {
+						int bytestoadd = (str.length + 1) % 64 == 0 ? (str.length + 1) : (str.length + 1) + (64 - ((str.length + 1) % 64));
+						byte[] newoutput = new byte[currentSize + bytestoadd];
+						System.arraycopy(output, 0, newoutput, 0, currentSize);
+						output = newoutput;
+						currentSize += bytestoadd;
+					}
+					System.arraycopy(str.bytes, 0, output, pos, str.length);
+					output[pos + str.length] = 0;
+					pos += str.length + 1;
+					break;
+				}
+				case 's': {
+					int size = 0;
+					while (i + 1 < fmt.length && fmt.bytes[i + 1] >= '0' && fmt.bytes[i + 1] <= '9') {
+						if (size >= Integer.MAX_VALUE / 10) throw new LuaError("bad argument #1 to 'pack' (invalid format)");
+						size = (size * 10) + (fmt.bytes[++i] - '0');
+					}
+					if (size > 16)
+						throw new LuaError(String.format("integral size (%d) out of limits [1,16]", size));
+					else if (size == 0) size = 8;
+					LuaString str = args.arg(argnum++).checkLuaString();
+					if (str.length >= Math.pow(2, (size * 8)))
+						throw new LuaError(String.format("bad argument #%d to 'pack' (string length does not fit in given size)", argnum - 1));
+					if (pos + str.length + size >= currentSize) {
+						int bytestoadd = (str.length + size) % 64 == 0 ? (str.length + size) : (str.length + size) + (64 - ((str.length + size) % 64));
+						byte[] newoutput = new byte[currentSize + bytestoadd];
+						System.arraycopy(output, 0, newoutput, 0, currentSize);
+						output = newoutput;
+						currentSize += bytestoadd;
+					}
+					packint(str.length, size, output, pos, 1, endianness, false);
+					System.arraycopy(str.bytes, 0, output, pos + size, str.length);
+					pos += str.length + size;
+					break;
+				}
+				case 'x': {
+					if (pos + 1 >= currentSize) {
+						byte[] newoutput = new byte[currentSize + 64];
+						System.arraycopy(output, 0, newoutput, 0, currentSize);
+						output = newoutput;
+						currentSize += 64;
+					}
+					output[pos++] = 0;
+					break;
+				}
+				case 'X': {
+					if (i + 1 >= fmt.length) throw new LuaError("invalid next option for option 'X'");
+					int size = 0;
+					if (fmt.bytes[++i] == 'i' || fmt.bytes[i] == 'I') {
+						while (i + 1 < fmt.length && fmt.bytes[i + 1] >= '0' && fmt.bytes[i + 1] <= '9') {
+							if (size >= Integer.MAX_VALUE / 10) throw new LuaError("bad argument #1 to 'pack' (invalid format)");
+							size = (size * 10) + (fmt.bytes[++i] - '0');
+						}
+						if (size > 16 || size == 0)
+							throw new LuaError(String.format("integral size (%d) out of limits [1,16]", size));
+					} else size = packoptsize(fmt.bytes[i], 0);
+					if (size < 1) throw new LuaError("invalid next option for option 'X'");
+					if (pos % Math.min(size, alignment) != 0 && alignment > 1)
+						for (int j = 0; pos % Math.min(size, alignment) != 0 && j < alignment; j++)
+							output[pos++] = 0;
+					break;
+				}
+				case ' ': break;
+				default: throw new LuaError(String.format("invalid format option '%c'", fmt.bytes[i]));
+			}
+		}
+		return LuaString.valueOf(output, 0, pos);
+	}
+
+	/**
+	 * string.packsize (fmt)
+	 *
+	 * Returns the size of a string resulting from string.pack with the given format.
+	 * The format string cannot have the variable-length options 's' or 'z'.
+	 */
+	static long packsize(LuaString fmt) throws LuaError {
+		long pos = 0;
+		int alignment = 1;
+		for (int i = 0; i < fmt.length; i++) {
+			switch (fmt.bytes[i]) {
+				case '!': {
+					int size = 0;
+					while (i + 1 < fmt.length && fmt.bytes[i + 1] >= '0' && fmt.bytes[i + 1] <= '9') {
+						if (size >= Integer.MAX_VALUE / 10) throw new LuaError("bad argument #1 to 'packsize' (invalid format)");
+						size = (size * 10) + (fmt.bytes[++i] - '0');
+					}
+					if (size > 16)
+						throw new LuaError(String.format("integral size (%d) out of limits [1,16]", size));
+					else if (size == 0) { // This is a bit hacky; it will probably need to be rewritten
+						String arch = System.getProperty("os.arch");
+						if (arch.equals("x86_64") || arch.equals("amd64") || arch.equals("x64"))
+							alignment = 8; // assume 8 bytes on 64-bit architectures
+						else alignment = 4; // assume 4 bytes on 32-bit architectures
+					} else alignment = size;
+					break;
+				}
+				case 'b':
+				case 'B':
+				case 'h':
+				case 'H':
+				case 'l':
+				case 'L':
+				case 'j':
+				case 'J':
+				case 'T': {
+					int size = packoptsize(fmt.bytes[i], 0);
+					if (pos % Math.min(size, alignment) != 0 && alignment > 1) for (int j = 0; pos % Math.min(size, alignment) != 0 && j < alignment; j++) pos++;
+					pos += size;
+					break;
+				}
+				case 'i':
+				case 'I': {
+					int size = 0;
+					while (i + 1 < fmt.length && fmt.bytes[i + 1] >= '0' && fmt.bytes[i + 1] <= '9') {
+						if (size >= Integer.MAX_VALUE / 10) throw new LuaError("bad argument #1 to 'packsize' (invalid format)");
+						size = (size * 10) + (fmt.bytes[++i] - '0');
+					}
+					if (size > 16)
+						throw new LuaError(String.format("integral size (%d) out of limits [1,16]", size));
+					else if (alignment > 1 && (size != 1 && size != 2 && size != 4 && size != 8 && size != 16))
+						throw new LuaError("bad argument #1 to 'pack' (format asks for alignment not power of 2)");
+					else if (size == 0) size = 4;
+					if (pos % Math.min(size, alignment) != 0 && alignment > 1) for (int j = 0; pos % Math.min(size, alignment) != 0 && j < alignment; j++) pos++;
+					pos += size;
+					break;
+				}
+				case 'f': {
+					if (pos % Math.min(4, alignment) != 0 && alignment > 1) for (int j = 0; pos % Math.min(4, alignment) != 0 && j < alignment; j++) pos++;
+					pos += 4;
+					break;
+				}
+				case 'd':
+				case 'n': {
+					if (pos % Math.min(8, alignment) != 0 && alignment > 1) for (int j = 0; pos % Math.min(8, alignment) != 0 && j < alignment; j++) pos++;
+					pos += 8;
+					break;
+				}
+				case 'c': {
+					int size = 0;
+					if (i + 1 == fmt.length || fmt.bytes[i + 1] < '0' || fmt.bytes[i + 1] > '9')
+						throw new LuaError("missing size for format option 'c'");
+					while (i + 1 < fmt.length && fmt.bytes[i + 1] >= '0' && fmt.bytes[i + 1] <= '9') {
+						if (size >= Integer.MAX_VALUE / 10) throw new LuaError("bad argument #1 to 'packsize' (invalid format)");
+						size = (size * 10) + (fmt.bytes[++i] - '0');
+					}
+					if (pos + size < pos || pos + size > Integer.MAX_VALUE) throw new LuaError("bad argument #1 to 'packsize' (format result too large)");
+					pos += size;
+					break;
+				}
+				case 'x': {
+					pos++;
+					break;
+				}
+				case 'X': {
+					if (i + 1 >= fmt.length) throw new LuaError("invalid next option for option 'X'");
+					int size = 0;
+					if (fmt.bytes[++i] == 'i' || fmt.bytes[i] == 'I') {
+						while (i + 1 < fmt.length && fmt.bytes[i + 1] >= '0' && fmt.bytes[i + 1] <= '9') {
+							if (size >= Integer.MAX_VALUE / 10) throw new LuaError("bad argument #1 to 'packsize' (invalid format)");
+							size = (size * 10) + (fmt.bytes[++i] - '0');
+						}
+						if (size > 16 || size == 0)
+							throw new LuaError(String.format("integral size (%d) out of limits [1,16]", size));
+					} else size = packoptsize(fmt.bytes[i], 0);
+					if (size < 1) throw new LuaError("invalid next option for option 'X'");
+					if (pos % Math.min(size, alignment) != 0 && alignment > 1) for (int j = 0; pos % Math.min(size, alignment) != 0 && j < alignment; j++) pos++;
+					break;
+				}
+				case ' ': case '<': case '>': case '=': break;
+				case 's': case 'z': throw new LuaError("bad argument #1 to 'packsize' (variable-length format)");
+				default: throw new LuaError(String.format("invalid format option '%c'", fmt.bytes[i]));
+			}
+		}
+		return pos;
+	}
+
 	/**
 	 * string.rep (s, n)
 	 *
@@ -652,6 +1046,192 @@ public class StringLib implements LuaLibrary {
 		} else {
 			return EMPTYSTRING;
 		}
+	}
+
+	private static class UnpackIntState {
+		long result = 0;
+		int size = 0;
+	}
+
+	private static UnpackIntState unpackint(byte[] str, int offset, int size, ByteOrder endianness, int alignment, boolean signed) {
+		UnpackIntState retval = new UnpackIntState();
+		if (offset % Math.min(size, alignment) != 0 && alignment > 1) for (int i = 0; offset % Math.min(size, alignment) != 0 && i < alignment; i++) {offset++; retval.size++;}
+		for (int i = 0; i < size; i++) {
+			retval.result |= (((long) str[offset + i] & 0xFF) << ((endianness == ByteOrder.BIG_ENDIAN ? size - i - 1 : i) * 8));
+			retval.size++;
+		}
+		if (signed && (retval.result & (1 << (size * 8 - 1))) != 0)
+			for (int i = size; i < 8; i++) retval.result |= ((long)0xFF & 0xFF) << (i * 8);
+		return retval;
+	}
+
+	/**
+	 * string.unpack (fmt, s [, pos])
+	 *
+	 * Returns the values packed in string s (see string.pack) according to the format string fmt.
+	 * An optional pos marks where to start reading in s (default is 1).
+	 * After the read values, this function also returns the index of the first unread byte in s.
+	 */
+	static Varargs unpack(Varargs args) throws LuaError {
+		LuaString fmt = args.arg(1).checkLuaString();
+		LuaString str = args.arg(2).checkLuaString();
+		int pos = args.arg(3).optInteger(1);
+		if (pos < 0) pos = str.length + pos;
+		else if (pos == 0) throw new LuaError("bad argument #3 to 'unpack' (initial position out of string)");
+		else pos--;
+		if (pos > str.length || pos < 0) throw new LuaError("bad argument #3 to 'unpack' (initial position out of string)");
+		ByteOrder endianness = ByteOrder.nativeOrder();
+		int alignment = 1;
+		LuaTable retval = new LuaTable();
+		for (int i = 0; i < fmt.length; i++) {
+			switch (fmt.bytes[i]) {
+				case '<': {
+					endianness = ByteOrder.LITTLE_ENDIAN;
+					break;
+				}
+				case '>': {
+					endianness = ByteOrder.BIG_ENDIAN;
+					break;
+				}
+				case '=': {
+					endianness = ByteOrder.nativeOrder();
+					break;
+				}
+				case '!': {
+					int size = 0;
+					while (i + 1 < fmt.length && fmt.bytes[i + 1] >= '0' && fmt.bytes[i + 1] <= '9') {
+						if (size >= Integer.MAX_VALUE / 10) throw new LuaError("bad argument #1 to 'unpack' (invalid format)");
+						size = (size * 10) + (fmt.bytes[++i] - '0');
+					}
+					if (size > 16)
+						throw new LuaError(String.format("integral size (%d) out of limits [1,16]", size));
+					else if (size == 0) { // This is a bit hacky; it will probably need to be rewritten
+						String arch = System.getProperty("os.arch");
+						if (arch.equals("x86_64") || arch.equals("amd64") || arch.equals("x64"))
+							alignment = 8; // assume 8 bytes on 64-bit architectures
+						else alignment = 4; // assume 4 bytes on 32-bit architectures
+					} else alignment = size;
+					break;
+				}
+				case 'b':
+				case 'B':
+				case 'h':
+				case 'H':
+				case 'l':
+				case 'L':
+				case 'j':
+				case 'J':
+				case 'T': {
+					if (pos + packoptsize(fmt.bytes[i], 0) > str.length) throw new LuaError("data string too short");
+					UnpackIntState res = unpackint(str.bytes, pos, packoptsize(fmt.bytes[i], 0), endianness, alignment, Character.isLowerCase(fmt.bytes[i]));
+					retval.insert(retval.length() + 1, LuaInteger.valueOf(res.result));
+					pos += res.size;
+					break;
+				}
+				case 'i':
+				case 'I': {
+					boolean signed = fmt.bytes[i] == 'i';
+					int size = 0;
+					while (i + 1 < fmt.length && fmt.bytes[i + 1] >= '0' && fmt.bytes[i + 1] <= '9') {
+						if (size >= Integer.MAX_VALUE / 10) throw new LuaError("bad argument #1 to 'unpack' (invalid format)");
+						size = (size * 10) + (fmt.bytes[++i] - '0');
+					}
+					if (size > 16)
+						throw new LuaError(String.format("integral size (%d) out of limits [1,16]", size));
+					else if (size > 8)
+						throw new LuaError(String.format("%d-byte integer does not fit into Lua Integer", size));
+					else if (size == 0) size = 4;
+					if (pos + size > str.length) throw new LuaError("data string too short");
+					UnpackIntState res = unpackint(str.bytes, pos, size, endianness, alignment, signed);
+					retval.insert(retval.length() + 1, LuaInteger.valueOf(res.result));
+					pos += res.size;
+					break;
+				}
+				case 'f': {
+					if (pos % Math.min(4, alignment) != 0 && alignment > 1) for (int j = 0; pos % Math.min(4, alignment) != 0 && j < alignment; j++) pos++;
+					if (pos + 4 > str.length) throw new LuaError("data string too short");
+					int l = 0;
+					for (int j = 0; j < 4; j++)
+						l |= (((int)str.bytes[pos + j] & 0xFF) << ((endianness == ByteOrder.BIG_ENDIAN ? 3 - j : j) * 8));
+					retval.insert(retval.length() + 1, LuaDouble.valueOf(Float.intBitsToFloat(l)));
+					pos += 4;
+					break;
+				}
+				case 'd':
+				case 'n': {
+					if (pos % Math.min(8, alignment) != 0 && alignment > 1) for (int j = 0; pos % Math.min(8, alignment) != 0 && j < alignment; j++) pos++;
+					if (pos + 8 > str.length) throw new LuaError("data string too short");
+					long l = 0;
+					for (int j = 0; j < 8; j++) l |= (((long)str.bytes[pos + j] & 0xFF) << ((endianness == ByteOrder.BIG_ENDIAN ? 7 - j : j) * 8));
+					retval.insert(retval.length() + 1, LuaDouble.valueOf(Double.longBitsToDouble(l)));
+					pos += 8;
+					break;
+				}
+				case 'c': {
+					int size = 0;
+					if (i + 1 == fmt.length || fmt.bytes[i + 1] < '0' || fmt.bytes[i + 1] > '9')
+						throw new LuaError("missing size for format option 'c'");
+					while (i + 1 < fmt.length && fmt.bytes[i + 1] >= '0' && fmt.bytes[i + 1] <= '9') {
+						if (size >= Integer.MAX_VALUE / 10) throw new LuaError("bad argument #1 to 'unpack' (invalid format)");
+						size = (size * 10) + (fmt.bytes[++i] - '0');
+					}
+					if (pos + size > str.length) throw new LuaError("data string too short");
+					retval.insert(retval.length() + 1, LuaString.valueOf(str.bytes, pos, size));
+					pos += size;
+					break;
+				}
+				case 'z': {
+					int size = 0;
+					while (str.bytes[pos + size] != 0) if (++size >= str.length) throw new LuaError("unfinished string for format 'z'");
+					retval.insert(retval.length() + 1, LuaString.valueOf(str.bytes, pos, size));
+					pos += size + 1;
+					break;
+				}
+				case 's': {
+					int size = 0;
+					while (i + 1 < fmt.length && fmt.bytes[i + 1] >= '0' && fmt.bytes[i + 1] <= '9') {
+						if (size >= Integer.MAX_VALUE / 10) throw new LuaError("bad argument #1 to 'unpack' (invalid format)");
+						size = (size * 10) + (fmt.bytes[++i] - '0');
+					}
+					if (size > 16)
+						throw new LuaError(String.format("integral size (%d) out of limits [1,16]", size));
+					else if (size == 0) size = 8;
+					if (pos + 8 > str.length) throw new LuaError("data string too short");
+					UnpackIntState num = unpackint(str.bytes, pos, size, endianness, alignment, false);
+					pos += num.size;
+					if (pos + num.result > str.length) throw new LuaError("data string too short");
+					retval.insert(retval.length() + 1, LuaString.valueOf(str.bytes, pos, (int)num.result));
+					pos += num.result;
+					break;
+				}
+				case 'x': {
+					pos++;
+					break;
+				}
+				case 'X': {
+					if (i + 1 >= fmt.length) throw new LuaError("invalid next option for option 'X'");
+					int size = -1;
+					if (fmt.bytes[++i] == 'i' || fmt.bytes[i] == 'I') {
+						while (i + 1 < fmt.length && fmt.bytes[i + 1] >= '0' && fmt.bytes[i + 1] <= '9') {
+							if (size >= Integer.MAX_VALUE / 10) throw new LuaError("bad argument #1 to 'unpack' (invalid format)");
+							size = (Math.max(size, 0) * 10) + (fmt.bytes[++i] - '0');
+						}
+						if (size > 16 || size == 0)
+							throw new LuaError(String.format("integral size (%d) out of limits [1,16]", size));
+						else if (size == -1) size = 4;
+					} else size = packoptsize(fmt.bytes[i], 0);
+					if (size < 1) throw new LuaError("invalid next option for option 'X'");
+					if (pos % Math.min(size, alignment) != 0 && alignment > 1) for (int j = 0; pos % Math.min(size, alignment) != 0 && j < alignment; j++) pos++;
+					break;
+				}
+				case ' ': break;
+				default: throw new LuaError(String.format("invalid format option '%c'", fmt.bytes[i]));
+			}
+		}
+		LuaValue[] retvar = new LuaValue[retval.length() + 1];
+		for (int i = 0; i < retval.length(); i++) retvar[i] = retval.rawget(i+1);
+		retvar[retval.length()] = LuaInteger.valueOf(pos + 1);
+		return varargsOf(retvar);
 	}
 
 	/**

--- a/src/test/java/org/squiddev/cobalt/AssertTests.java
+++ b/src/test/java/org/squiddev/cobalt/AssertTests.java
@@ -142,10 +142,12 @@ public class AssertTests {
 	@ValueSource(strings = {
 		"db",
 		"utf8",
+		"tpack",
 	})
 	public void lua53(String name) throws Exception {
 		ScriptHelper helpers = new ScriptHelper("/assert/lua5.3/");
 		helpers.setup();
+		helpers.globals.load(helpers.state, new Bit32Lib());
 		helpers.globals.load(helpers.state, new Utf8Lib());
 
 		helpers.runWithDump(name);

--- a/src/test/resources/assert/lua5.3/tpack.lua
+++ b/src/test/resources/assert/lua5.3/tpack.lua
@@ -1,0 +1,323 @@
+-- $Id: tpack.lua,v 1.13 2016/11/07 13:11:28 roberto Exp $
+-- See Copyright Notice in file all.lua
+
+local pack = string.pack
+local packsize = string.packsize
+local unpack = string.unpack
+
+print "testing pack/unpack"
+
+-- maximum size for integers
+local NB = 4
+
+local sizeshort = packsize("h")
+local sizeint = packsize("i")
+local sizelong = packsize("l")
+local sizesize_t = packsize("T")
+local sizeLI = packsize("j")
+local sizefloat = packsize("f")
+local sizedouble = packsize("d")
+local sizenumber = packsize("n")
+local little = (pack("i2", 1) == "\1\0")
+local align = packsize("!xXi16")
+
+assert(1 <= sizeshort and sizeshort <= sizeint and sizeint <= sizelong and
+       sizefloat <= sizedouble)
+
+print("platform:")
+print(string.format(
+  "\tshort %d, int %d, long %d, size_t %d, float %d, double %d,\n\z
+   \tlua Integer %d, lua Number %d",
+   sizeshort, sizeint, sizelong, sizesize_t, sizefloat, sizedouble,
+   sizeLI, sizenumber))
+print("\t" .. (little and "little" or "big") .. " endian")
+print("\talignment: " .. align)
+
+
+-- check errors in arguments
+function checkerror (msg, f, ...)
+  local status, err = pcall(f, ...)
+  -- print(status, err, msg)
+  assert(not status and string.find(err, msg))
+end
+
+-- minimum behavior for integer formats
+assert(unpack("B", pack("B", 0xff)) == 0xff)
+assert(unpack("b", pack("b", 0x7f)) == 0x7f)
+assert(unpack("b", pack("b", -0x80)) == -0x80)
+
+assert(unpack("H", pack("H", 0xffff)) == 0xffff)
+assert(unpack("h", pack("h", 0x7fff)) == 0x7fff)
+assert(unpack("h", pack("h", -0x8000)) == -0x8000)
+
+assert(unpack("L", pack("L", 0xffffffff)) == 0xffffffff)
+assert(unpack("l", pack("l", 0x7fffffff)) == 0x7fffffff)
+assert(unpack("l", pack("l", -0x80000000)) == -0x80000000)
+
+
+for i = 1, NB do
+  -- small numbers with signal extension ("\xFF...")
+  local s = string.rep("\xff", i)
+  assert(pack("i" .. i, -1) == s)
+  assert(packsize("i" .. i) == #s)
+  assert(unpack("i" .. i, s) == -1)
+
+  -- small unsigned number ("\0...\xAA")
+  s = "\xAA" .. string.rep("\0", i - 1)
+  assert(pack("<I" .. i, 0xAA) == s)
+  assert(unpack("<I" .. i, s) == 0xAA)
+  assert(pack(">I" .. i, 0xAA) == s:reverse())
+  assert(unpack(">I" .. i, s:reverse()) == 0xAA)
+end
+
+do
+  local lnum = 0x04030201
+  local s = pack("<j", lnum)
+  assert(unpack("<j", s) == lnum)
+  assert(unpack("<i" .. sizeLI + 1, s .. "\0") == lnum)
+  assert(unpack("<i" .. sizeLI + 1, s .. "\0") == lnum)
+
+  for i = sizeLI + 1, NB do
+    print(i)
+    local s = pack("<j", -lnum)
+    assert(unpack("<j", s) == -lnum)
+    -- strings with (correct) extra bytes
+    assert(unpack("<i" .. i, s .. ("\xFF"):rep(i - sizeLI)) == -lnum)
+    assert(unpack(">i" .. i, ("\xFF"):rep(i - sizeLI) .. s:reverse()) == -lnum)
+    assert(unpack("<I" .. i, s .. ("\0"):rep(i - sizeLI)) == -lnum)
+
+    -- overflows
+    checkerror("does not fit", unpack, "<I" .. i, ("\x00"):rep(i - 1) .. "\1")
+    checkerror("does not fit", unpack, ">i" .. i, "\1" .. ("\x00"):rep(i - 1))
+  end
+end
+
+for i = 1, sizeLI do
+  local lstr = "\1\2\3\4"
+  local lnum = 0x04030201
+  local n = bit32.band(lnum, bit32.bnot(bit32.lshift(-1, i * 8)))
+  local s = string.sub(lstr, 1, i)
+  assert(pack("<i" .. i, n) == s)
+  assert(pack(">i" .. i, n) == s:reverse())
+  assert(unpack(">i" .. i, s:reverse()) == n)
+end
+
+-- sign extension
+do
+  local u = 0xf0
+  for i = 1, sizeLI - 1 do
+    assert(unpack("<i"..i, "\xf0"..("\xff"):rep(i - 1)) == -16)
+    assert(unpack(">I"..i, "\xf0"..("\xff"):rep(i - 1)) == u)
+    u = u * 256 + 0xff
+  end
+end
+
+-- mixed endianness
+do
+  assert(pack(">i2 <i2", 10, 20) == "\0\10\20\0")
+  local a, b = unpack("<i2 >i2", "\10\0\0\20")
+  assert(a == 10 and b == 20)
+  assert(pack("=i4", 2001) == pack("i4", 2001))
+end
+
+print("testing invalid formats")
+
+checkerror("out of limits", pack, "i0", 0)
+checkerror("out of limits", pack, "i" .. 17, 0)
+checkerror("out of limits", pack, "!" .. 17, 0)
+checkerror("%(17%) out of limits %[1,16%]", pack, "Xi" .. 17)
+checkerror("invalid format option 'r'", pack, "i3r", 0)
+checkerror("16%-byte integer", unpack, "i16", string.rep('\3', 16))
+checkerror("not power of 2", pack, "!4i3", 0);
+checkerror("missing size", pack, "c", "")
+checkerror("variable%-length format", packsize, "s")
+checkerror("variable%-length format", packsize, "z")
+
+-- overflow in option size  (error will be in digit after limit)
+checkerror("invalid format", packsize, "c1" .. string.rep("0", 40))
+
+if packsize("i") == 4 then
+  -- result would be 2^31  (2^3 repetitions of 2^28 strings)
+  local s = string.rep("c268435456", 2^3)
+  checkerror("too large", packsize, s)
+  -- one less is OK
+  s = string.rep("c268435456", 2^3 - 1) .. "c268435455"
+  assert(packsize(s) == 0x7fffffff)
+end
+
+-- overflow in packing
+for i = 1, sizeLI - 1 do
+  local umax = bit32.lshift(1, (i * 8)) - 1
+  local max = bit32.rshift(umax, 1)
+  local min = -max - 1
+  checkerror("overflow", pack, "<I" .. i, -1)
+  checkerror("overflow", pack, "<I" .. i, min)
+  checkerror("overflow", pack, ">I" .. i, umax + 1)
+
+  checkerror("overflow", pack, ">i" .. i, umax)
+  checkerror("overflow", pack, ">i" .. i, max + 1)
+  checkerror("overflow", pack, "<i" .. i, min - 1)
+
+  assert(unpack(">i" .. i, pack(">i" .. i, max)) == max)
+  assert(unpack("<i" .. i, pack("<i" .. i, min)) == min)
+  assert(unpack(">I" .. i, pack(">I" .. i, umax)) == umax)
+end
+
+-- Lua integer size
+--assert(unpack(">j", pack(">j", math.maxinteger)) == math.maxinteger)
+--assert(unpack("<j", pack("<j", math.mininteger)) == math.mininteger)
+assert(unpack("<J", pack("<j", -1)) == 0xFFFFFFFF)   -- maximum unsigned integer
+
+if little then
+  assert(pack("f", 24) == pack("<f", 24))
+else
+  assert(pack("f", 24) == pack(">f", 24))
+end
+
+print "testing pack/unpack of floating-point numbers" 
+
+for _, n in ipairs{0, -1.1, 1.9, 1/0, -1/0, 1e20, -1e20, 0.1, 2000.7} do
+    assert(unpack("n", pack("n", n)) == n)
+    assert(unpack("<n", pack("<n", n)) == n)
+    assert(unpack(">n", pack(">n", n)) == n)
+    assert(pack("<f", n) == pack(">f", n):reverse())
+    assert(pack(">d", n) == pack("<d", n):reverse())
+end
+
+-- for non-native precisions, test only with "round" numbers
+for _, n in ipairs{0, -1.5, 1/0, -1/0, 1e10, -1e9, 0.5, 2000.25} do
+  assert(unpack("<f", pack("<f", n)) == n)
+  assert(unpack(">f", pack(">f", n)) == n)
+  assert(unpack("<d", pack("<d", n)) == n)
+  assert(unpack(">d", pack(">d", n)) == n)
+end
+
+print "testing pack/unpack of strings"
+do
+  local s = string.rep("abc", 1000)
+  assert(pack("zB", s, 247) == s .. "\0\xF7")
+  local s1, b = unpack("zB", s .. "\0\xF9")
+  assert(b == 249 and s1 == s)
+  s1 = pack("s", s)
+  assert(unpack("s", s1) == s)
+
+  checkerror("does not fit", pack, "s1", s)
+
+  checkerror("contains zeros", pack, "z", "alo\0");
+
+  for i = 2, NB do
+    local s1 = pack("s" .. i, s)
+    assert(unpack("s" .. i, s1) == s and #s1 == #s + i)
+  end
+end
+
+do
+  local x = pack("s", "alo")
+  checkerror("too short", unpack, "s", x:sub(1, -2))
+  checkerror("too short", unpack, "c5", "abcd")
+  checkerror("out of limits", pack, "s100", "alo")
+end
+
+do
+  assert(pack("c0", "") == "")
+  assert(packsize("c0") == 0)
+  assert(unpack("c0", "") == "")
+  assert(pack("<! c3", "abc") == "abc")
+  assert(packsize("<! c3") == 3)
+  assert(pack(">!4 c6", "abcdef") == "abcdef")
+  assert(pack("c3", "123") == "123")
+  assert(pack("c0", "") == "")
+  assert(pack("c8", "123456") == "123456\0\0")
+  assert(pack("c88", "") == string.rep("\0", 88))
+  assert(pack("c188", "ab") == "ab" .. string.rep("\0", 188 - 2))
+  local a, b, c = unpack("!4 z c3", "abcdefghi\0xyz")
+  assert(a == "abcdefghi" and b == "xyz" and c == 14)
+  checkerror("longer than", pack, "c3", "1234")
+end
+
+
+-- testing multiple types and sequence
+do
+  local x = pack("<b h b f d f n i", 1, 2, 3, 4, 5, 6, 7, 8)
+  assert(#x == packsize("<b h b f d f n i"))
+  local a, b, c, d, e, f, g, h = unpack("<b h b f d f n i", x)
+  assert(a == 1 and b == 2 and c == 3 and d == 4 and e == 5 and f == 6 and
+         g == 7 and h == 8) 
+end
+
+print "testing alignment"
+do
+  assert(pack(" < i1 i2 ", 2, 3) == "\2\3\0")   -- no alignment by default
+  local x = pack(">!8 b Xh i4 i8 c1 Xi8", -12, 100, 200, "\xEC")
+  assert(#x == packsize(">!8 b Xh i4 i8 c1 Xi8"))
+  assert(x == "\xf4" .. "\0\0\0" ..
+              "\0\0\0\100" ..
+              "\0\0\0\0\0\0\0\xC8" .. 
+              "\xEC" .. "\0\0\0\0\0\0\0")
+  local a, b, c, d, pos = unpack(">!8 c1 Xh i4 i8 b Xi8 XI XH", x)
+  assert(a == "\xF4" and b == 100 and c == 200 and d == -20 and (pos - 1) == #x)
+
+  x = pack(">!4 c3 c4 c2 z i4 c5 c2 Xi4",
+                  "abc", "abcd", "xz", "hello", 5, "world", "xy")
+  assert(x == "abcabcdxzhello\0\0\0\0\0\5worldxy\0")
+  local a, b, c, d, e, f, g, pos = unpack(">!4 c3 c4 c2 z i4 c5 c2 Xh Xi4", x)
+  assert(a == "abc" and b == "abcd" and c == "xz" and d == "hello" and
+         e == 5 and f == "world" and g == "xy" and (pos - 1) % 4 == 0)
+
+  x = pack(" b b Xd b Xb x", 1, 2, 3)
+  assert(packsize(" b b Xd b Xb x") == 4)
+  assert(x == "\1\2\3\0")
+  a, b, c, pos = unpack("bbXdb", x)
+  assert(a == 1 and b == 2 and c == 3 and pos == #x)
+
+  -- only alignment
+  assert(packsize("!8 xXi8") == 8)
+  local pos = unpack("!8 xXi8", "0123456701234567"); assert(pos == 9)
+  assert(packsize("!8 xXi2") == 2)
+  local pos = unpack("!8 xXi2", "0123456701234567"); assert(pos == 3)
+  assert(packsize("!2 xXi2") == 2)
+  local pos = unpack("!2 xXi2", "0123456701234567"); assert(pos == 3)
+  assert(packsize("!2 xXi8") == 2)
+  local pos = unpack("!2 xXi8", "0123456701234567"); assert(pos == 3)
+  assert(packsize("!16 xXi16") == 16)
+  local pos = unpack("!16 xXi16", "0123456701234567"); assert(pos == 17)
+
+  checkerror("invalid next option", pack, "X")
+  checkerror("invalid next option", unpack, "XXi", "")
+  checkerror("invalid next option", unpack, "X i", "")
+  checkerror("invalid next option", pack, "Xc1")
+end
+
+do    -- testing initial position
+  local x = pack("i4i4i4i4", 1, 2, 3, 4)
+  for pos = 1, 16, 4 do
+    local i, p = unpack("i4", x, pos)
+    assert(i == math.floor(pos/4) + 1 and p == pos + 4)
+  end
+
+  -- with alignment
+  for pos = 0, 12 do    -- will always round position to power of 2
+    local i, p = unpack("!4 i4", x, pos + 1)
+    assert(i == math.floor((pos + 3)/4) + 1 and p == i*4 + 1)
+  end
+
+  -- negative indices
+  local i, p = unpack("!4 i4", x, -4)
+  assert(i == 4 and p == 17)
+  local i, p = unpack("!4 i4", x, -7)
+  assert(i == 4 and p == 17)
+  local i, p = unpack("!4 i4", x, -#x)
+  assert(i == 1 and p == 5)
+
+  -- limits
+  for i = 1, #x + 1 do
+    assert(unpack("c0", x, i) == "")
+  end
+  checkerror("out of string", unpack, "c0", x, 0)
+  checkerror("out of string", unpack, "c0", x, #x + 2)
+  checkerror("out of string", unpack, "c0", x, -(#x + 1))
+ 
+end
+
+print "OK"
+


### PR DESCRIPTION
This PR adds three new functions from Lua 5.3:
* `string.pack (fmt, v1, v2, ...)`: Returns a binary string containing the values `v1`, `v2`, etc. packed (that is, serialized in binary form) according to the format string `fmt`. 
* `string.packsize (fmt)`: Returns the size of a string resulting from string.pack with the given format. The format string cannot have the variable-length options 's' or 'z'. 
* `string.unpack (fmt, s [, pos])`: Returns the values packed in string s according to the format string `fmt`. An optional `pos` marks where to start reading in `s` (default is 1). After the read values, this function also returns the index of the first unread byte in `s`. 

This passes the Lua 5.3.4 tests for the functions, with a few adjustments made regarding number sizes due to differences in Lua 5.1 & Java. I have included these tests in the PR as well.

The code is a bit messy right now and may need some refactoring to look decent, but it works.