### PR TITLE
Explicitly state string cache size requirement

### DIFF
--- a/src/main/java/org/squiddev/cobalt/LuaString.java
+++ b/src/main/java/org/squiddev/cobalt/LuaString.java
@@ -53,7 +53,7 @@ import java.io.InputStream;
 public final class LuaString extends LuaBaseString {
 	/**
 	 * Size of cache of recent short strings. This is the maximum number of LuaStrings that
-	 * will be retained in the cache of recent short strings.
+	 * will be retained in the cache of recent short strings. Must be a power of 2.
 	 */
 	public static final int RECENT_STRINGS_CACHE_SIZE = 128;
 


### PR DESCRIPTION
The cache modular reduction is done through bit masking and only works perfectly when the modulus is a power of 2.