### PR TITLE
Various fixes on tables

### DIFF
--- a/src/main/java/org/squiddev/cobalt/LuaTable.java
+++ b/src/main/java/org/squiddev/cobalt/LuaTable.java
@@ -328,12 +328,7 @@ public final class LuaTable extends LuaValue {
 
 	@Override
 	public LuaValue getn() {
-		for (int n = getArrayLength(); n > 0; --n) {
-			if (!rawget(n).isNil()) {
-				return LuaInteger.valueOf(n);
-			}
-		}
-		return ZERO;
+		return LuaInteger.valueOf(length());
 	}
 
 
@@ -688,10 +683,10 @@ public final class LuaTable extends LuaValue {
 	public boolean compare(LuaState state, int i, int j, LuaValue cmpfunc) throws LuaError, UnwindThrowable {
 		LuaValue a, b;
 
-		a = strengthen(array[i]);
-		b = strengthen(array[j]);
+		a = strengthen(rawget(i));
+		b = strengthen(rawget(j));
 
-		if (a.isNil() || b.isNil()) {
+		if (a.isNil() && b.isNil()) {
 			return false;
 		}
 		if (!cmpfunc.isNil()) {
@@ -702,9 +697,9 @@ public final class LuaTable extends LuaValue {
 	}
 
 	public void swap(int i, int j) {
-		Object a = array[i];
-		array[i] = array[j];
-		array[j] = a;
+		LuaValue a = rawget(i);
+		rawset(i, rawget(j));
+		rawset(j, a);
 	}
 
 	/**

--- a/src/main/java/org/squiddev/cobalt/LuaTable.java
+++ b/src/main/java/org/squiddev/cobalt/LuaTable.java
@@ -660,40 +660,22 @@ public final class LuaTable extends LuaValue {
 	// ----------------- sort support -----------------------------
 	//
 	// implemented heap sort from wikipedia
-	//
-	// Only sorts the contiguous array part.
-	//
-
-	/**
-	 * Prepare the table for being sorted. Trimming unused values
-	 *
-	 * @return The length of this array.
-	 * @throws LuaError On a runtime error.
-	 */
-	public int prepSort() throws LuaError {
-		if (weakValues) dropWeakArrayValues();
-		int n = array.length;
-		while (n > 0 && array[n - 1] == NIL) {
-			--n;
-		}
-
-		return n;
-	}
-
 	public boolean compare(LuaState state, int i, int j, LuaValue cmpfunc) throws LuaError, UnwindThrowable {
 		LuaValue a, b;
 
 		a = strengthen(rawget(i));
 		b = strengthen(rawget(j));
 
-		if (a.isNil() && b.isNil()) {
-			return false;
-		}
 		if (!cmpfunc.isNil()) {
 			return OperationHelper.call(state, cmpfunc, a, b).toBoolean();
-		} else {
-			return OperationHelper.lt(state, a, b);
 		}
+		// To avoid breaking sort on tables that do contain nil values, but are not specifying a comparison function
+		// we should ensure that the behaviour is the same has before
+		// this means not swapping A B if either A or B is nil
+		if (a.isNil() || b.isNil()) {
+			return false;
+		}
+		return OperationHelper.lt(state, a, b);
 	}
 
 	public void swap(int i, int j) {

--- a/src/main/java/org/squiddev/cobalt/lib/TableLib.java
+++ b/src/main/java/org/squiddev/cobalt/lib/TableLib.java
@@ -114,7 +114,7 @@ public class TableLib implements LuaLibrary {
 				case 0: { // "sort" (table [, comp]) -> void
 					LuaTable table = args.arg(1).checkTable();
 					LuaValue compare = args.isNoneOrNil(2) ? NIL : args.arg(2).checkFunction();
-					int n = table.prepSort();
+					int n = table.length();
 					if (n > 1) {
 						SortState res = new SortState(table, n, compare);
 						di.state = res;
@@ -341,7 +341,7 @@ public class TableLib implements LuaLibrary {
 				int end = counter;
 				try {
 					for (; end > 0; ) {
-						table.swap(end, 0);
+						table.swap(end + 1, 1);
 						normalSiftDown(state, table, 0, --end, compare, res);
 					}
 				} catch (UnwindThrowable e) {
@@ -360,14 +360,14 @@ public class TableLib implements LuaLibrary {
 				siftState = 0;
 
 				child = root * 2 + 1;
-				if (child < end && table.compare(state, child, child + 1, compare)) {
+				if (child < end && table.compare(state, child + 1, child + 2, compare)) {
 					++child;
 				}
 
 				siftState = 1;
 
-				if (table.compare(state, root, child, compare)) {
-					table.swap(root, child);
+				if (table.compare(state, root + 1, child +  1, compare)) {
+					table.swap(root + 1, child + 1);
 					root = child;
 				} else {
 					return;
@@ -394,7 +394,7 @@ public class TableLib implements LuaLibrary {
 				// This is technically state 1 now, but we care about the exit
 				// point rather than the entry point
 				try {
-					value = table.compare(state, root, child, compare);
+					value = table.compare(state, root + 1, child + 1, compare);
 				} catch (UnwindThrowable e) {
 					res.child = child;
 					res.siftState = 1;
@@ -403,7 +403,7 @@ public class TableLib implements LuaLibrary {
 				// Allow fall through
 			case 1:
 				if (value) {
-					table.swap(root, child);
+					table.swap(root + 1, child + 1);
 					return child;
 				} else {
 					return -1;

--- a/src/test/java/org/squiddev/cobalt/AssertTests.java
+++ b/src/test/java/org/squiddev/cobalt/AssertTests.java
@@ -42,7 +42,7 @@ import static org.squiddev.cobalt.ValueFactory.valueOf;
  */
 public class AssertTests {
 	@ParameterizedTest(name = ParameterizedTest.ARGUMENTS_WITH_NAMES_PLACEHOLDER)
-	@ValueSource(strings = {"table-hash-01", "table-hash-02", "table-hash-03", "table-lengths"})
+	@ValueSource(strings = {"table-hash-01", "table-hash-02", "table-hash-03", "table-lengths", "table-sort"})
 	public void tables(String name) throws IOException, CompileException, LuaError, InterruptedException {
 		ScriptHelper helpers = new ScriptHelper("/assert/table/");
 		helpers.setup();

--- a/src/test/resources/assert/table/table-lengths.lua
+++ b/src/test/resources/assert/table/table-lengths.lua
@@ -4,3 +4,15 @@ assert(#{ 1, 2, 3, nil, 5, nil, nil, 8, 9 } == 9)
 assert(#{ 1, 2, 3, nil, 5, nil, 7, 8 } == 8)
 assert(#{ 1, 2, 3, nil, 5, nil, 7, 8, 9 } == 9)
 assert(#{ 1, nil, [2] = 2, 3 } == 3)
+
+-- Ensure table.getn on sparse tables behaves identically to PUC Lua
+print(table.getn({[1]="e",[2]="a",[3]="b",[4]="c"})==4)
+print(table.getn({[1]="e",[2]="a",[3]="b",[4]="c",[8]="f"})==8)
+
+-- Ensure table.maxn on sparse tables behaves identically to PUC Lua
+print(table.maxn({[1]="e",[2]="a",[3]="b",[4]="c"})==4)
+print(table.maxn({[1]="e",[2]="a",[3]="b",[4]="c",[8]="f"})==8)
+
+-- Ensure rawlen on sparse tables behaves identically to PUC Lua
+print(rawlen({[1]="e",[2]="a",[3]="b",[4]="c"})==4)
+print(rawlen({[1]="e",[2]="a",[3]="b",[4]="c",[8]="f"})==8)

--- a/src/test/resources/assert/table/table-sort.lua
+++ b/src/test/resources/assert/table/table-sort.lua
@@ -1,6 +1,6 @@
 -- Ensure table.sort on sparse tables behaves identically to PUC Lua.
 
-local testTable = {[1]="e",[2]="a",[3]="b",[4]="c",[8]="d"}
+local testTable = {[1]="e",[2]="a",[3]="d",[4]="c",[8]="b"}
 
 table.sort(testTable, function(a, b)
   if not a then
@@ -9,8 +9,8 @@ table.sort(testTable, function(a, b)
   if not b then
     return true
   end
-  return a < b end
-end
+  return a < b
+end)
 
 assert(testTable[1]=="a")
 assert(testTable[2]=="b")

--- a/src/test/resources/assert/table/table-sort.lua
+++ b/src/test/resources/assert/table/table-sort.lua
@@ -1,0 +1,19 @@
+-- Ensure table.sort on sparse tables behaves identically to PUC Lua.
+
+local testTable = {[1]="e",[2]="a",[3]="b",[4]="c",[8]="d"}
+
+table.sort(testTable, function(a, b)
+  if not a then
+    return false
+  end
+  if not b then
+    return true
+  end
+  return a < b end
+end
+
+assert(testTable[1]=="a")
+assert(testTable[2]=="b")
+assert(testTable[3]=="c")
+assert(testTable[4]=="d")
+assert(testTable[5]=="e")


### PR DESCRIPTION
# What does this PR do ?

This PR attemps to move Cobalt a bit closer to PUC Lua implementation
- `table.getn`  now returns the `table.length()`
- `LuaTable.compare` & `LuaTable.swap` are now using `rawget / rawset` to access element of the table
- `HeapSort` has been fixed to increment indices given to `LuaTable.compare` & `LuaTable.swap`
   so they can be between [1, length] for `rawget` and `rawset` to work.
- Add new assertions testing the behaviour of `table.getn`, `table.maxn`, `rawlen`, `table.sort`

Also fixes issue [#58 Small issue with tables created in Cobalt](https://github.com/SquidDev/Cobalt/issues/58)

I didn't implement `table.sort` calling `__index` and `__newindex` since I tried it in lua5.1 and that was not the case.
But I think if we wanted to support this behaviour from lua5.3 we could do it in another PR since this one is mainly for bug fixing an incorrect behaviour.

**Before**
```lua
local test = {[1]="d",[2]="a",[3]="b",[4]="c"}
table.sort(test, function(a, b) return a < b end)
for k, v in ipairs(test) do
  print(k, v)
end
-- 1 d
-- 2 a
-- 3 b
-- 4 c
```

**After**
```lua
local test = {[1]="d",[2]="a",[3]="b",[4]="c"}
table.sort(test, function(a, b) return a < b end)
for k, v in ipairs(test) do
  print(k, v)
end
-- 1 a
-- 2 b
-- 3 c
-- 4 d
```