### PR TITLE
Add __gc metamethod support

### DIFF
--- a/src/main/java/org/squiddev/cobalt/CachedMetamethod.java
+++ b/src/main/java/org/squiddev/cobalt/CachedMetamethod.java
@@ -31,6 +31,7 @@ public enum CachedMetamethod {
 	INDEX(Constants.INDEX),
 	NEWINDEX(Constants.NEWINDEX),
 	LEN(Constants.LEN),
+	GC(Constants.GC),
 	EQ(Constants.EQ);
 
 	private final LuaString key;

--- a/src/main/java/org/squiddev/cobalt/Constants.java
+++ b/src/main/java/org/squiddev/cobalt/Constants.java
@@ -237,6 +237,11 @@ public class Constants {
 	public static final LuaString PAIRS = valueOf("__pairs");
 
 	/**
+	 * LuaString constant with value "__gc" for use as metatag
+	 */
+	public static final LuaString GC = valueOf("__gc");
+
+	/**
 	 * LuaString constant with value ""
 	 */
 	public static final LuaString EMPTYSTRING = valueOf("");


### PR DESCRIPTION
This PR adds support for `__gc` garbage collection/finalization metamethods. It uses the `finalize` method of `Object` to call a Lua function when the table is collected by the Java GC. To reduce the huge performance hit caused by the mere existence of `finalize` in an object, the method is delegated to a separate object, which is only instantiated when a `__gc` metamethod is set on the table. This should result in average tables keeping the same performance, though tables with `__gc` will experience a slight performance reduction.

The behavior should match PUC Lua relatively closely: objects are only "marked for finalization" (have `Finalizer` instantiated) when `__gc` is directly present in the metatable, and it will only call the metamethod if it's a function. Since GC behavior is unspecified in Lua, Java's non-determinism of calling `finalize` should work out to match close enough. However, applications that exit before the GC can call `finalize` won't call `__gc`, which doesn't match Lua's behavior of calling every `__gc` before closing the state.